### PR TITLE
Update golang.org/x/crypto dependency from v0.37.0 to v0.45.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
-	golang.org/x/crypto v0.37.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/term v0.31.0 // indirect


### PR DESCRIPTION
This pull request updates a dependency version in the `go.mod` file. Specifically, it upgrades the `golang.org/x/crypto` package from version `v0.37.0` to `v0.45.0`. This ensures the project uses the latest security patches and features from the crypto library.